### PR TITLE
Make List primaryText take only one line

### DIFF
--- a/lib/List.js
+++ b/lib/List.js
@@ -279,7 +279,7 @@ export default class List extends Component {
                     <View style={{flex:1,justifyContent:'center',}}>
                         <View style={styles.firstLine}>
                             <View style={styles.primaryTextContainer}>
-                                <Text style={[styles.primaryText,{color: primaryColor}]}>{primaryText}</Text>
+                                <Text numberOfLines={1} style={[styles.primaryText,{color: primaryColor}]}>{primaryText}</Text>
                             </View>
                             { (lines > 2 && !!rightIcon) || <View style={styles.captionTextContainer}>
                                 <Text style={styles.captionText}>{captionText}</Text>
@@ -370,7 +370,8 @@ const styles = StyleSheet.create({
         flexDirection: 'row'
     },
     primaryTextContainer: {
-        flex: 1
+        flex: 1,
+        paddingRight: 16
     },
     captionTextContainer: {
         alignSelf: 'flex-start',


### PR DESCRIPTION
Also adds `paddingRight` to the primaryText to not hit the captionText element.
