### PR TITLE
Allow toolbar actions

### DIFF
--- a/lib/Toolbar.js
+++ b/lib/Toolbar.js
@@ -34,6 +34,7 @@ export default class Toolbar extends Component {
         onIconClicked: PropTypes.func,
         title: PropTypes.string,
         titleColor: PropTypes.string,
+        actions: PropTypes.array
     };
     state = {};
 
@@ -44,7 +45,8 @@ export default class Toolbar extends Component {
             primary,
             titleColor,
             navIconName,
-            onIconClicked
+            onIconClicked,
+            actions
             } = this.props;
 
         var themeMap = {
@@ -65,7 +67,7 @@ export default class Toolbar extends Component {
             <View style={[
                 styles.toolbar,{backgroundColor :themeStyle.backgroundColor}]}>
                 <IconButton onPressButton={onIconClicked}>
-                    <Icon name='menu'
+                    <Icon name={ navIconName || 'menu' }
                           size={24}
                           color={themeStyle.iconColor}
                           style={styles.icon}/>
@@ -77,6 +79,19 @@ export default class Toolbar extends Component {
                         color: themeStyle.color
                     }
                 ]}>{title}</Text>
+                {
+                    actions &&
+                    actions.map(function(action) {
+                        return (
+                            <IconButton key={action.icon} onPressButton={action.onPress}>
+                                <Icon name={action.icon}
+                                      size={24}
+                                      color={themeStyle.iconColor}
+                                      style={styles.icon}/>
+                            </IconButton>
+                        );
+                    })
+                }
             </View>
         );
     }


### PR DESCRIPTION
@binggg Proof of concept at the moment as I'm having an issue, which I'll explain.

This PR allows you to do the following:

```
<Toolbar
        title='MyAwesomeApp'
    navIconName='menu'
    titleColor='#ffffff'
    actions={ [
            { icon: 'settings', onPress: function() {
            console.log('pressed settings');
        } },
        { icon: 'magnify', onPress: () => {
            console.log('pressed magnify');
        } }
    ] }
    style={ styles.toolbar }
/>
```

Which results in:

![image](https://cloud.githubusercontent.com/assets/842078/11537365/88c61fac-9914-11e5-8f64-3567bbcc2e95.png)
- It fixes a bug(?) where the `navIconName` was always set to `menu`, now it defaults to menu.

The issue I can't figure out though is the `onPress` function is never triggered. I've tried to trace it back to the `Ripple` component, it looks like `onPress` is never getting triggered on that component. When adding it, it complains the proptype passed down from IconButton is not a function!

Let me know what you think anyway.
