### PR TITLE
Optional menu button

### DIFF
--- a/lib/Toolbar.js
+++ b/lib/Toolbar.js
@@ -66,17 +66,22 @@ export default class Toolbar extends Component {
         return (
             <View style={[
                 styles.toolbar,{backgroundColor :themeStyle.backgroundColor}]}>
-                <IconButton onPressButton={onIconClicked}>
-                    <Icon name={ navIconName || 'menu' }
-                          size={24}
-                          color={themeStyle.iconColor}
-                          style={styles.icon}/>
-                </IconButton>
+                {
+                    navIconName && (
+                        <IconButton onPressButton={onIconClicked}>
+                            <Icon name={navIconName || "menu"}
+                                  size={24}
+                                  color={themeStyle.iconColor}
+                                  style={styles.icon}/>
+                        </IconButton>
+                    )
+                }
                 <Text style={[
                     styles.title,
                     TYPO.paperFontTitle,
                     {
-                        color: themeStyle.color
+                        color: themeStyle.color,
+                        marginLeft: navIconName ? styles.title.marginLeft : 56
                     }
                 ]}>{title}</Text>
                 {


### PR DESCRIPTION
As per #19, this only creates a menu button if navIconName is defined. 

~~However, I noticed a bug where you don't get an icon if the navIconName is named anything other than "menu", which doesn't seem to be as intended. I can fix that, but it might be best done in a different pull request since it could break the current examples.~~
