### PR TITLE
Support Babel 6

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,23 +1,13 @@
-var Components = {
-    COLOR: require('./config').COLOR,
-    TYPO: require('./config').TYPO,
-    ICON_NAME: require('./config').ICON_NAME,
-    COLOR_NAME: require('./config').COLOR_NAME,
-    THEME_NAME: require('./config').THEME_NAME,
-    PRIMARY: require('./config').PRIMARY,
-    Button: require('./Button'),
-    Checkbox: require('./Checkbox'),
-    CheckboxGroup : require('./CheckboxGroup'),
-    Icon: require('./Icon'),
-    RadioButton: require('./RadioButton'),
-    RadioButtonGroup: require('./RadioButtonGroup'),
-    Toolbar: require('./Toolbar'),
-    List: require('./List'),
-    Subheader: require('./Subheader'),
-    Avatar: require('./Avatar'),
-    Divider: require('./Divider'),
-    Ripple: require('./Ripple')
-};
-
-module.exports = Components;
-
+export { COLOR, TYPO, ICON_NAME, COLOR_NAME, THEME_NAME } from './config';
+export { default as Button } from './Button';
+export { default as Checkbox } from './Checkbox';
+export { default as CheckboxGroup } from './CheckboxGroup';
+export { default as Icon } from './Icon';
+export { default as RadioButton } from './RadioButton';
+export { default as RadioButtonGroup } from './RadioButtonGroup';
+export { default as Toolbar } from './Toolbar';
+export { default as List } from './List';
+export { default as Subheader } from './Subheader';
+export { default as Avatar } from './Avatar';
+export { default as Divider } from './Divider';
+export { default as Ripple } from './Ripple';


### PR DESCRIPTION
Although this doesn't fully support Babel 6 because the project still contains an invalid `.babelrc` file (for Babel 6), once removed this project can be exported successfully.  Also works backwards too, so it doesn't actually break anything.
